### PR TITLE
feat: add vscode header

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Usage of leetdoad:
     	Debug logs
   -version
     	Show the current leetdoad version
+  -header
+      Include a header and footer in the scraped submission file in the style of the [VSCode LeetCode extension](https://marketplace.visualstudio.com/items?itemName=LeetCode.vscode-leetcode).
 ```
 
 Leetdoad uses a cookie to download your latest submissions from Leetcode, and cookie can be found in your browser when you visit Leetcode website. If you don't know how to find the cookie, Google is your friend.

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 	f := flags{}
 	flag.StringVar(&f.configFilePath, "config-file", ".leetdoad.yaml", "Path of the leetdoad config file")
 	flag.StringVar(&f.cookie, "cookie", "", "Cookie that used for scraping problems and solutions from Leetcode website, you can either pass it from here, or set LEETCODE_COOKIE env")
-	flag.BoolVar(&f.debug, "debug", true, "Debug logs")
+	flag.BoolVar(&f.debug, "debug", false, "Debug logs")
 	flag.BoolVar(&f.version, "version", false, "Show the current leetdoad version")
 	flag.BoolVar(&f.header, "header", false, "Add LeetCode VSCode extension header")
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -34,15 +34,18 @@ type flags struct {
 	cookie         string
 	debug          bool
 	version        bool
+	header         bool
 }
 
 func main() {
 	f := flags{}
 	flag.StringVar(&f.configFilePath, "config-file", ".leetdoad.yaml", "Path of the leetdoad config file")
 	flag.StringVar(&f.cookie, "cookie", "", "Cookie that used for scraping problems and solutions from Leetcode website, you can either pass it from here, or set LEETCODE_COOKIE env")
-	flag.BoolVar(&f.debug, "debug", false, "Debug logs")
+	flag.BoolVar(&f.debug, "debug", true, "Debug logs")
 	flag.BoolVar(&f.version, "version", false, "Show the current leetdoad version")
+	flag.BoolVar(&f.header, "header", false, "Add LeetCode VSCode extension header")
 	flag.Parse()
+
 	if f.version {
 		printVersion()
 		return
@@ -58,7 +61,7 @@ func main() {
 	client := http.Client{
 		Timeout: 5 * time.Second,
 	}
-	if err := scraper.NewScraper(client, cfg).Scrape(); err != nil {
+	if err := scraper.NewScraper(client, cfg, f.header).Scrape(); err != nil {
 		log.Fatal().Msgf("failed to scrape solutions: %s", err.Error())
 	}
 }

--- a/pkg/leetcode/submission.go
+++ b/pkg/leetcode/submission.go
@@ -13,7 +13,7 @@ type Submission struct {
 	Code      string `json:"code"`
 }
 
-func (s Submission) WriteTo(fileName string, q Question) error {
+func (s Submission) WriteTo(fileName string, q Question, includeHeader bool) error {
 	if err := os.MkdirAll(filepath.Dir(fileName), os.ModePerm); err != nil {
 		return err
 	}
@@ -29,7 +29,8 @@ func (s Submission) WriteTo(fileName string, q Question) error {
 		}
 	}
 
-	f.WriteString(fmt.Sprintf(`/*
+	if includeHeader {
+		f.WriteString(fmt.Sprintf(`/*
 * @lc app=leetcode id=%d lang=%s
 *
 * [%d] %s
@@ -37,14 +38,17 @@ func (s Submission) WriteTo(fileName string, q Question) error {
 
 // @lc code=start
 `, q.FrontendQuestionID, s.Language, q.FrontendQuestionID, q.QuestionTitleSlug))
+	}
 
 	_, err = f.WriteString(s.Code)
 	if err != nil {
 		return err
 	}
 
-	f.WriteString(`
+	if includeHeader {
+		f.WriteString(`
 // @lc code=end`)
+	}
 
 	return nil
 }

--- a/pkg/leetcode/submission.go
+++ b/pkg/leetcode/submission.go
@@ -1,6 +1,7 @@
 package leetcode
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -12,7 +13,7 @@ type Submission struct {
 	Code      string `json:"code"`
 }
 
-func (s Submission) WriteTo(fileName string) error {
+func (s Submission) WriteTo(fileName string, q Question) error {
 	if err := os.MkdirAll(filepath.Dir(fileName), os.ModePerm); err != nil {
 		return err
 	}
@@ -27,10 +28,24 @@ func (s Submission) WriteTo(fileName string) error {
 			return err
 		}
 	}
+
+	f.WriteString(fmt.Sprintf(`/*
+* @lc app=leetcode id=%d lang=%s
+*
+* [%d] %s
+*/
+
+// @lc code=start
+`, q.FrontendQuestionID, s.Language, q.FrontendQuestionID, q.QuestionTitleSlug))
+
 	_, err = f.WriteString(s.Code)
 	if err != nil {
 		return err
 	}
+
+	f.WriteString(`
+// @lc code=end`)
+
 	return nil
 }
 

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -84,7 +84,7 @@ func (s *scraper) Scrape() error {
 			}
 			fileName := fmt.Sprintf("%s/%s.%s", pwd, buf.String(), s.config.LanguageMap[sub.Language])
 			buf.Reset()
-			if err := sub.WriteTo(fileName); err != nil {
+			if err := sub.WriteTo(fileName, q); err != nil {
 				return err
 			}
 			log.Debug().

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -31,14 +31,16 @@ type filePattern struct {
 }
 
 type scraper struct {
-	client http.Client
-	config *config.InConfig
+	client        http.Client
+	config        *config.InConfig
+	includeHeader bool
 }
 
-func NewScraper(client http.Client, config *config.InConfig) *scraper {
+func NewScraper(client http.Client, config *config.InConfig, includeHeader bool) *scraper {
 	return &scraper{
-		client: client,
-		config: config,
+		client:        client,
+		config:        config,
+		includeHeader: includeHeader,
 	}
 }
 
@@ -84,7 +86,7 @@ func (s *scraper) Scrape() error {
 			}
 			fileName := fmt.Sprintf("%s/%s.%s", pwd, buf.String(), s.config.LanguageMap[sub.Language])
 			buf.Reset()
-			if err := sub.WriteTo(fileName, q); err != nil {
+			if err := sub.WriteTo(fileName, q, s.includeHeader); err != nil {
 				return err
 			}
 			log.Debug().


### PR DESCRIPTION
Adds a new `-header` command line flag to include a header and footer in the scraped submission file in the style of the [VSCode LeetCode extension](https://marketplace.visualstudio.com/items?itemName=LeetCode.vscode-leetcode).